### PR TITLE
[Fix] workround with limit of oneOf

### DIFF
--- a/sdk-generator/api-spec/amn-o2c.yaml
+++ b/sdk-generator/api-spec/amn-o2c.yaml
@@ -671,13 +671,12 @@ components:
               type: string
               description: 'REPL = Next Truck <br>
                 RUSH = Small Package <br>
-                **REPL offers could be present from Michelin and/or extended supplier. REPL offer from extended supplier would typically result in a same day or next day delivery.<br>
-                **REPL offers from Michelin could also include "backorder" offers designated by deliveryDate = 2999-12-31 <br>
+                REPL offers could be present from Michelin and/or extended supplier. REPL offer from extended supplier would typically result in a same day or next day delivery.<br>
+                REPL offers from Michelin could also include "backorder" offers designated by deliveryDate = 2999-12-31 <br>
                 If order is for pickup from supplier DC, this value would be set as null'
             pickUp:
               type: string
-              description:
-                'Indicator = "Y" in order request would indicate customer intends to pick up product from local supplier warehouse. <br>
+              description: 'Indicator = "Y" in order request would indicate customer intends to pick up product from local supplier warehouse. <br>
                 If order is for pickup from supplier DC, set value as "Y".<br>
                 If order is not for pickup from supplier DC, set value as null and set transportPriority field.'
             deliveryRemarks:
@@ -871,22 +870,38 @@ components:
             - title: 'Order is NOT for Pickup from supplier DC'
               properties:
                 transportPriority:
+                  type: string
                   enum: 
                     - "REPL"
                     - "RUSH"
                   example: "REPL"
                 pickUp:
+                  type: string
                   example: null
               required: ["transportPriority"]
               description: 'Option 1: transportPriority is REPL or RUSH, and pickUp must be null'
             - title: "Order is for Pickup from supplier DC"
               properties:
                 transportPriority:
+                  type: string
+                  enum: 
+                    - 'REPL'
+                    - 'RUSH'
+                    - null
+                  description: 'REPL = Next Truck <br>
+                    RUSH = Small Package <br>
+                    REPL offers could be present from Michelin and/or extended supplier. REPL offer from extended supplier would typically result in a same day or next day delivery.<br>
+                    REPL offers from Michelin could also include "backorder" offers designated by deliveryDate = 2999-12-31 <br>
+                    If order is for pickup from supplier DC, this value would be set as null'
                   example: null
                 pickUp:
+                  type: string
                   enum:
-                    - "Y"
-                  example: "Y"
+                    - 'Y'
+                  example: 'Y'
+                  description: 'Indicator = "Y" in order request would indicate customer intends to pick up product from local supplier warehouse. <br>
+                    If order is for pickup from supplier DC, set value as "Y".<br>
+                    If order is not for pickup from supplier DC, set value as null and set transportPriority field.'
               required: ["pickUp"]
               description: 'Option 2: pickUp is Y, and transportPriority must be null.' 
   

--- a/sdk/amn-o2c-sdk-java/api/openapi.yaml
+++ b/sdk/amn-o2c-sdk-java/api/openapi.yaml
@@ -589,13 +589,12 @@ components:
             example: "1"
             type: string
           transportPriority:
-            description: "REPL = Next Truck <br> RUSH = Small Package <br> **REPL\
-              \ offers could be present from Michelin and/or extended supplier. REPL\
-              \ offer from extended supplier would typically result in a same day\
-              \ or next day delivery.<br> **REPL offers from Michelin could also include\
-              \ \"backorder\" offers designated by deliveryDate = 2999-12-31 <br>\
-              \ If order is for pickup from supplier DC, this value would be set as\
-              \ null"
+            description: "REPL = Next Truck <br> RUSH = Small Package <br> REPL offers\
+              \ could be present from Michelin and/or extended supplier. REPL offer\
+              \ from extended supplier would typically result in a same day or next\
+              \ day delivery.<br> REPL offers from Michelin could also include \"\
+              backorder\" offers designated by deliveryDate = 2999-12-31 <br> If order\
+              \ is for pickup from supplier DC, this value would be set as null"
             type: string
           pickUp:
             description: "Indicator = \"Y\" in order request would indicate customer\
@@ -635,6 +634,7 @@ components:
               example: REPL
               type: string
             pickUp:
+              type: string
               example: null
           required:
           - transportPriority
@@ -642,8 +642,25 @@ components:
         - description: "Option 2: pickUp is Y, and transportPriority must be null."
           properties:
             transportPriority:
+              description: "REPL = Next Truck <br> RUSH = Small Package <br> REPL\
+                \ offers could be present from Michelin and/or extended supplier.\
+                \ REPL offer from extended supplier would typically result in a same\
+                \ day or next day delivery.<br> REPL offers from Michelin could also\
+                \ include \"backorder\" offers designated by deliveryDate = 2999-12-31\
+                \ <br> If order is for pickup from supplier DC, this value would be\
+                \ set as null"
+              enum:
+              - REPL
+              - RUSH
+              - null
+              type: string
               example: null
             pickUp:
+              description: "Indicator = \"Y\" in order request would indicate customer\
+                \ intends to pick up product from local supplier warehouse. <br> If\
+                \ order is for pickup from supplier DC, set value as \"Y\".<br> If\
+                \ order is not for pickup from supplier DC, set value as null and\
+                \ set transportPriority field."
               enum:
               - "Y"
               example: "Y"

--- a/sdk/amn-o2c-sdk-java/docs/EDIWheelC11OrderCreationRequest.md
+++ b/sdk/amn-o2c-sdk-java/docs/EDIWheelC11OrderCreationRequest.md
@@ -9,14 +9,23 @@
 |------------ | ------------- | ------------- | -------------|
 |**documentId** | **String** | Fixed value \&quot;C1\&quot; |  |
 |**variant** | **String** | Fixed value \&quot;1\&quot; |  [optional] |
-|**transportPriority** | **Object** |  |  |
-|**pickUp** | [**PickUpEnum**](#PickUpEnum) |  |  |
+|**transportPriority** | [**TransportPriorityEnum**](#TransportPriorityEnum) | REPL &#x3D; Next Truck &lt;br&gt; RUSH &#x3D; Small Package &lt;br&gt; REPL offers could be present from Michelin and/or extended supplier. REPL offer from extended supplier would typically result in a same day or next day delivery.&lt;br&gt; REPL offers from Michelin could also include \&quot;backorder\&quot; offers designated by deliveryDate &#x3D; 2999-12-31 &lt;br&gt; If order is for pickup from supplier DC, this value would be set as null |  |
+|**pickUp** | [**PickUpEnum**](#PickUpEnum) | Indicator &#x3D; \&quot;Y\&quot; in order request would indicate customer intends to pick up product from local supplier warehouse. &lt;br&gt; If order is for pickup from supplier DC, set value as \&quot;Y\&quot;.&lt;br&gt; If order is not for pickup from supplier DC, set value as null and set transportPriority field. |  |
 |**deliveryRemarks** | **String** |  |  [optional] |
 |**customerReference** | [**EDIWheelC11OrderCreationRequestAllOfCustomerReference**](EDIWheelC11OrderCreationRequestAllOfCustomerReference.md) |  |  |
 |**supplierParty** | [**EDIWheelC11OrderCreationRequestAllOfSupplierParty**](EDIWheelC11OrderCreationRequestAllOfSupplierParty.md) |  |  |
 |**buyerParty** | [**EDIWheelC11OrderCreationRequestAllOfBuyerParty**](EDIWheelC11OrderCreationRequestAllOfBuyerParty.md) |  |  |
 |**consignee** | [**EDIWheelC11OrderCreationRequestAllOfConsignee**](EDIWheelC11OrderCreationRequestAllOfConsignee.md) |  |  [optional] |
 |**orderLine** | [**List&lt;EDIWheelC11OrderCreationRequestAllOfOrderLine&gt;**](EDIWheelC11OrderCreationRequestAllOfOrderLine.md) |  |  [optional] |
+
+
+
+## Enum: TransportPriorityEnum
+
+| Name | Value |
+|---- | -----|
+| REPL | &quot;REPL&quot; |
+| RUSH | &quot;RUSH&quot; |
 
 
 

--- a/sdk/amn-o2c-sdk-java/src/main/java/com/michelin/adk/amn/o2c/model/EDIWheelC11OrderCreationRequest.java
+++ b/sdk/amn-o2c-sdk-java/src/main/java/com/michelin/adk/amn/o2c/model/EDIWheelC11OrderCreationRequest.java
@@ -67,13 +67,65 @@ public class EDIWheelC11OrderCreationRequest {
   @javax.annotation.Nullable
   private String variant;
 
+  /**
+   * REPL &#x3D; Next Truck &lt;br&gt; RUSH &#x3D; Small Package &lt;br&gt; REPL offers could be present from Michelin and/or extended supplier. REPL offer from extended supplier would typically result in a same day or next day delivery.&lt;br&gt; REPL offers from Michelin could also include \&quot;backorder\&quot; offers designated by deliveryDate &#x3D; 2999-12-31 &lt;br&gt; If order is for pickup from supplier DC, this value would be set as null
+   */
+  @JsonAdapter(TransportPriorityEnum.Adapter.class)
+  public enum TransportPriorityEnum {
+    REPL("REPL"),
+    
+    RUSH("RUSH");
+
+    private String value;
+
+    TransportPriorityEnum(String value) {
+      this.value = value;
+    }
+
+    public String getValue() {
+      return value;
+    }
+
+    @Override
+    public String toString() {
+      return String.valueOf(value);
+    }
+
+    public static TransportPriorityEnum fromValue(String value) {
+      for (TransportPriorityEnum b : TransportPriorityEnum.values()) {
+        if (b.value.equals(value)) {
+          return b;
+        }
+      }
+      return null;
+    }
+
+    public static class Adapter extends TypeAdapter<TransportPriorityEnum> {
+      @Override
+      public void write(final JsonWriter jsonWriter, final TransportPriorityEnum enumeration) throws IOException {
+        jsonWriter.value(enumeration.getValue());
+      }
+
+      @Override
+      public TransportPriorityEnum read(final JsonReader jsonReader) throws IOException {
+        String value =  jsonReader.nextString();
+        return TransportPriorityEnum.fromValue(value);
+      }
+    }
+
+    public static void validateJsonElement(JsonElement jsonElement) throws IOException {
+      String value = jsonElement.getAsString();
+      TransportPriorityEnum.fromValue(value);
+    }
+  }
+
   public static final String SERIALIZED_NAME_TRANSPORT_PRIORITY = "transportPriority";
   @SerializedName(SERIALIZED_NAME_TRANSPORT_PRIORITY)
   @javax.annotation.Nullable
-  private Object transportPriority = null;
+  private TransportPriorityEnum transportPriority;
 
   /**
-   * Gets or Sets pickUp
+   * Indicator &#x3D; \&quot;Y\&quot; in order request would indicate customer intends to pick up product from local supplier warehouse. &lt;br&gt; If order is for pickup from supplier DC, set value as \&quot;Y\&quot;.&lt;br&gt; If order is not for pickup from supplier DC, set value as null and set transportPriority field.
    */
   @JsonAdapter(PickUpEnum.Adapter.class)
   public enum PickUpEnum {
@@ -198,21 +250,21 @@ public class EDIWheelC11OrderCreationRequest {
   }
 
 
-  public EDIWheelC11OrderCreationRequest transportPriority(@javax.annotation.Nullable Object transportPriority) {
+  public EDIWheelC11OrderCreationRequest transportPriority(@javax.annotation.Nullable TransportPriorityEnum transportPriority) {
     this.transportPriority = transportPriority;
     return this;
   }
 
   /**
-   * Get transportPriority
+   * REPL &#x3D; Next Truck &lt;br&gt; RUSH &#x3D; Small Package &lt;br&gt; REPL offers could be present from Michelin and/or extended supplier. REPL offer from extended supplier would typically result in a same day or next day delivery.&lt;br&gt; REPL offers from Michelin could also include \&quot;backorder\&quot; offers designated by deliveryDate &#x3D; 2999-12-31 &lt;br&gt; If order is for pickup from supplier DC, this value would be set as null
    * @return transportPriority
    */
   @javax.annotation.Nullable
-  public Object getTransportPriority() {
+  public TransportPriorityEnum getTransportPriority() {
     return transportPriority;
   }
 
-  public void setTransportPriority(@javax.annotation.Nullable Object transportPriority) {
+  public void setTransportPriority(@javax.annotation.Nullable TransportPriorityEnum transportPriority) {
     this.transportPriority = transportPriority;
   }
 
@@ -223,7 +275,7 @@ public class EDIWheelC11OrderCreationRequest {
   }
 
   /**
-   * Get pickUp
+   * Indicator &#x3D; \&quot;Y\&quot; in order request would indicate customer intends to pick up product from local supplier warehouse. &lt;br&gt; If order is for pickup from supplier DC, set value as \&quot;Y\&quot;.&lt;br&gt; If order is not for pickup from supplier DC, set value as null and set transportPriority field.
    * @return pickUp
    */
   @javax.annotation.Nonnull
@@ -476,6 +528,11 @@ public class EDIWheelC11OrderCreationRequest {
       if ((jsonObj.get("variant") != null && !jsonObj.get("variant").isJsonNull()) && !jsonObj.get("variant").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `variant` to be a primitive type in the JSON string but got `%s`", jsonObj.get("variant").toString()));
       }
+      if ((jsonObj.get("transportPriority") != null && !jsonObj.get("transportPriority").isJsonNull()) && !jsonObj.get("transportPriority").isJsonPrimitive()) {
+        throw new IllegalArgumentException(String.format("Expected the field `transportPriority` to be a primitive type in the JSON string but got `%s`", jsonObj.get("transportPriority").toString()));
+      }
+      // validate the required field `transportPriority`
+      TransportPriorityEnum.validateJsonElement(jsonObj.get("transportPriority"));
       if (!jsonObj.get("pickUp").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `pickUp` to be a primitive type in the JSON string but got `%s`", jsonObj.get("pickUp").toString()));
       }


### PR DESCRIPTION
Fix the issue caused by oneOf syntax in OAS 3.0 as a workaround. it is due to the limit in the current generator version